### PR TITLE
Allow for mix export into .wav/.mp3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A program that dynamically generates repeating hypnosis audio, complete with sou
 - **Dynamic Audio Generation**: Combines multiple audio layers, including background tones and echo effects.
 - **Live Updating Audio**: Updating the source text file changes the lines in the generated audio without needing to restart the application.
 - **Display Current Line**: The program prints the currently playing line to the terminal, allowing you or others to see what the user is currently hearing.
+- **Inline Pause Directives**: Insert natural timing using `[pause X seconds]` tokens inside a line; they add silence without being spoken.
 
 ## Table of Contents
 1. [Requirements](#requirements)
@@ -94,6 +95,31 @@ Also note that the program will automatically update the audio if you change the
 
 You can specify a different text file by passing the `-t <text_filepath>` argument when running the program. See the [Running the Program](#running-the-program) section for details on how to do this.
 
+#### Inline Pause Directives
+You can embed timed pauses directly within a single line using the syntax:
+
+```
+[pause X seconds]
+```
+
+Where `X` can be an integer or decimal (e.g. `1`, `1.5`, `2`, `2.25`). The directive is:
+- Case-insensitive (`[Pause 2 Seconds]` also works)
+- Not spoken by the text-to-speech engine
+- Replaced by *silence* of the specified duration in the rendered audio
+
+You can place multiple pauses inside a line. Example:
+```
+Take a deep breath in [pause 1.5 seconds] and out [pause 2 seconds] sinking deeper now.
+```
+This produces a single audio file for the entire line with two natural gaps. The pauses are resolved **at generation time**; changing pause durations counts as a changed line (a new audio file will be generated because the full text including the pause tokens is hashed).
+
+Guidelines:
+- Keep pauses within a reasonable range (fractions of a second up to ~10 seconds are fine).
+- A line containing only a pause is ignored (silence-only lines are not generated as separate files).
+- Spacing inside the directive must at least separate the words, e.g. `[pause   2   seconds]` is fine; just make sure the number is present.
+
+If you ever want a literal bracketed phrase read out, avoid the exact `pause ... seconds` pattern (e.g. rephrase or remove the word `seconds`).
+
 ### Config File
 The config file is a JSON file that contains various settings for the audio generation. By default, it is located in `config.json` in the project root, and contains all the default settings. The following options are available:
 
@@ -136,7 +162,7 @@ You can provide the following arguments when running the program:
 - `-t <text_filepath>` or `--text-filepath <text_filepath>`: Specify a different text file to use for the hypnosis lines. This will override the default `lines.txt` file in the project root.
 - `-c <config_filepath>` or `--config-filepath <config_filepath>`: Specify a different config file to use. This will override the `config.json` file in the project root.
 - `--debug`: Enable debug logging.
-- `--render-mix`: Render all lines, tone, and mantra into a single audio file (no playback).
+- `--render-mix`: Render all lines, tone, and mantra into a single audio file (no playback). The mantra will begin at the configured `mantra_start_delay` (from your config). If that delay is longer than the total length of the rendered line audio, the mantra is skipped. Any missing hypnosis line audio is automatically generated first (including handling inline pause directives) before the mix is assembled.
 - `--mix-output <filename>`: Specify the output file name for the rendered mix (default: `full_mix.wav`).
 
 For example, to render a mix and save it as `my_mix.wav`:
@@ -246,3 +272,4 @@ Further issues can be reported on the [GitHub Issues page](https://github.com/s1
 2. **Install ffmpeg using Homebrew:**
    ```sh
    brew install ffmpeg
+   ```

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ You can provide the following arguments when running the program:
 - `-c <config_filepath>` or `--config-filepath <config_filepath>`: Specify a different config file to use. This will override the `config.json` file in the project root.
 - `--debug`: Enable debug logging.
 - `--render-mix`: Render all lines, tone, and mantra into a single audio file (no playback). The mantra will begin at the configured `mantra_start_delay` (from your config). If that delay is longer than the total length of the rendered line audio, the mantra is skipped. Any missing hypnosis line audio is automatically generated first (including handling inline pause directives) before the mix is assembled.
-- `--mix-output <filename>`: Specify the output file name for the rendered mix (default: `full_mix.wav`).
+- `--mix-output <filename>`: Specify the output file name for the rendered mix (default: `full_mix.wav`), tested and supports .wav and .mp3 .
 
 For example, to render a mix and save it as `my_mix.wav`:
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A program that dynamically generates repeating hypnosis audio, complete with sou
 
 ## Requirements
 - [Python 3.13](https://www.python.org/downloads/release/python-313/) or higher.
+- **ffmpeg** (required for audio exporting):
+  - See [How to Install ffmpeg](#how-to-install-ffmpeg) below.
 - **Windows Only**:
   - [Microsoft Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist) - required for audio effects. Ensure you download the right version for your system architecture.
 - **Optional**:
@@ -128,13 +130,19 @@ As with installation, I recommend using [uv](https://docs.astral.sh/uv/) to run 
 3. To stop the program, press `Ctrl+C` in the terminal.
 
 #### Providing Arguments
-You can provide the following arguments when running the program with `uv`:
-- `-t <text_filepath>`: Specify a different text file to use for the hypnosis lines. This will override the default `lines.txt` file in the project root.
-- `-c <config_filepath>`: Specify a different config file to use. This will override the `config.json` file in the project root.
 
-For example, to run the program with a different text file and config file, you would use:
+You can provide the following arguments when running the program:
+
+- `-t <text_filepath>` or `--text-filepath <text_filepath>`: Specify a different text file to use for the hypnosis lines. This will override the default `lines.txt` file in the project root.
+- `-c <config_filepath>` or `--config-filepath <config_filepath>`: Specify a different config file to use. This will override the `config.json` file in the project root.
+- `--debug`: Enable debug logging.
+- `--render-mix`: Render all lines, tone, and mantra into a single audio file (no playback).
+- `--mix-output <filename>`: Specify the output file name for the rendered mix (default: `full_mix.wav`).
+
+For example, to render a mix and save it as `my_mix.wav`:
 ```bash
 uv run main.py -t /path/to/your/text.txt -c /path/to/your/config.json
+uv run main.py --render-mix --mix-output hypno_mix.wav
 ```
 
 ### Using `pip`
@@ -195,3 +203,46 @@ Currently I'm aware of:
 - Occasional issues where an audio line fails to play, but the rest of the audio continues playing, and the next line plays as expected.
 
 Further issues can be reported on the [GitHub Issues page](https://github.com/s10boi/dynamic_hypno_generator/issues)
+
+## How to Install ffmpeg
+
+### For Windows
+
+1. **Download ffmpeg:**
+   - Go to [https://ffmpeg.org/download.html](https://ffmpeg.org/download.html)
+   - Under “Windows,” choose a build provider (e.g., [gyan.dev](https://www.gyan.dev/ffmpeg/builds/))
+   - Download the “Release full” zip file.
+
+2. **Extract ffmpeg:**
+   - Unzip the downloaded file to a folder, e.g., `C:\ffmpeg`
+   - Inside, find the `bin` folder (e.g., `C:\ffmpeg\ffmpeg-6.x-full_build\bin`) containing `ffmpeg.exe`.
+
+3. **Add ffmpeg to your PATH:**
+   - Press `Win + S` and search for “environment variables”.
+   - Click **Edit the system environment variables**.
+   - In the System Properties window, click **Environment Variables**.
+   - Under **System variables**, select `Path` and click **Edit**.
+   - Click **New** and add the path to the `bin` folder, e.g.:
+     ```
+     C:\ffmpeg\ffmpeg-6.x-full_build\bin
+     ```
+   - Click **OK** to save and close all dialogs.
+
+4. **Verify Installation:**
+   - Open a new Command Prompt window.
+   - Type:
+     ```
+     ffmpeg -version
+     ```
+   - You should see version information printed.
+
+---
+
+### For Mac
+
+1. **Install Homebrew** (if you don’t have it):  
+   [https://brew.sh/](https://brew.sh/)
+
+2. **Install ffmpeg using Homebrew:**
+   ```sh
+   brew install ffmpeg

--- a/main.py
+++ b/main.py
@@ -129,7 +129,7 @@ def main() -> None:
         )
         return
 
-
+    # =====================
     # HYPNO LINE GENERATION
     # =====================
     # Start generating audio files from the lines in the source text file
@@ -160,6 +160,7 @@ def main() -> None:
     while not hypno_line_mapping:
         time.sleep(0.1)
 
+    # ================
     # BACKGROUND AUDIO
     # ================
     if config.background_audio:
@@ -174,6 +175,7 @@ def main() -> None:
         # If there's a background audio file, delay before starting to play the hypno lines
         time.sleep(config.initial_line_delay)
 
+    # ===================
     # HYPNO LINE PLAYBACK
     # ===================
     # Two line players are needed - one starting just after the first line is played, but while it's still playing the
@@ -205,6 +207,7 @@ def main() -> None:
         )
         line_player_thread.start()
 
+    # ================
     # MANTRA PLAYBACK
     # ================
     if config.mantra_filepath:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ numpy==2.3.1
     #   pedalboard
 pedalboard==0.9.16 ; sys_platform == 'win32'
     # via dynamic-hypno-generator (pyproject.toml)
+pydub==0.25.1
+    # via dynamic-hypno-generator (pyproject.toml)
 pedalboard==0.9.17 ; sys_platform != 'win32'
     # via dynamic-hypno-generator (pyproject.toml)
 pydantic==2.11.7

--- a/src/audio/tts.py
+++ b/src/audio/tts.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import re
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loguru import logger
+from pydub import AudioSegment
 
 from src.audio.speech import get_engine
 from src.hypno_line import HypnoLine, clean_line
@@ -16,6 +18,39 @@ if TYPE_CHECKING:
 
 FILE_WRITE_WAIT = 2
 SLEEP_PERIOD = 5
+PAUSE_PATTERN = re.compile(r"\[pause\s+(\d+(?:\.\d+)?)\s+seconds?\]", re.IGNORECASE)
+
+
+def _parse_line_segments(line: str) -> list[tuple[str, str]]:
+    """Parse a line into ('speech', text) and ('pause', seconds) segments.
+
+    Returns a sequence preserving order. Pause segments store the numeric seconds as a string.
+    """
+    segments: list[tuple[str, str]] = []
+    last_index = 0
+
+    for match in PAUSE_PATTERN.finditer(line):
+        start, end = match.span()
+        # Speech before this pause
+        speech_chunk = line[last_index:start].strip()
+        if speech_chunk:
+            segments.append(("speech", speech_chunk))
+        # Pause
+        seconds = match.group(1)
+        segments.append(("pause", seconds))
+        last_index = end
+
+    # Remaining speech
+    tail = line[last_index:].strip()
+    if tail:
+        segments.append(("speech", tail))
+
+    # If the line was only a pause directive (unlikely given formatting), we still return the pause
+    if not segments and PAUSE_PATTERN.fullmatch(line.strip()):
+        seconds = PAUSE_PATTERN.fullmatch(line.strip()).group(1)  # type: ignore[reportOptionalCall]
+        segments.append(("pause", seconds))
+
+    return segments
 
 
 def _get_lines_from_file(text_filepath: Path) -> list[str]:
@@ -71,38 +106,109 @@ def generate_audio(
 
             lines = _get_lines_from_file(text_filepath)
 
+            # For lines containing pauses we will assemble the final audio after TTS generation of speech segments.
+            combine_jobs: list[tuple[HypnoLine, list[tuple[str, str]], list[Path]]] = []
+
             for line in lines:
                 hypno_line = hypno_line_mapping.get(line) or HypnoLine.from_text(
                     text=line,
                     output_audio_dir=output_audio_dir,
                 )
 
+                # Parse segments for pause directives
+                segments = _parse_line_segments(line)
+                has_pause = any(kind == "pause" for kind, _ in segments)
+
                 if not hypno_line.filepath.exists():
-                    logger.debug(f"Generating audio for line: {line.strip()}")
-                    engine.save_to_file(line, str(hypno_line.filepath))
-                    new_lines += 1
+                    if has_pause:
+                        temp_paths: list[Path] = []
+                        # Queue TTS generation for each speech segment only
+                        for idx, (kind, value) in enumerate(segments):
+                            if kind == "speech":
+                                temp_path = hypno_line.filepath.parent / f"{hypno_line.filepath.stem}_seg{idx}.tmp.wav"
+                                engine.save_to_file(value, str(temp_path))
+                                temp_paths.append(temp_path)
+                        if temp_paths:
+                            new_lines += 1  # Count as one new composite line
+                        combine_jobs.append((hypno_line, segments, temp_paths))
+                    else:
+                        # No pauses, single segment line
+                        if segments and segments[0][0] == "speech":
+                            engine.save_to_file(segments[0][1], str(hypno_line.filepath))
+                            new_lines += 1
+                        else:
+                            # Empty line after cleaning and parsing: skip
+                            logger.debug(f"Skipping empty or pause-only line: {line}")
 
                 new_exported_files[line] = hypno_line
 
             # Save all queued up audio files
             if new_lines:
-                logger.debug(f"Saving {new_lines} audio files to disk.")
+                logger.debug(f"Saving {new_lines} new (including composite) audio files to disk.")
                 engine.runAndWait()
 
-                # Wait until all audio files are confirmed to exist and are non-empty before updating exported_files
+                # Wait until all speech segment audio files exist and are non-empty
                 while not all(
-                    hypno_line.filepath.exists() and Path(hypno_line.filepath).stat().st_size > 0
-                    for hypno_line in new_exported_files.values()
+                    (
+                        (hypno_line.filepath.exists() and hypno_line.filepath.stat().st_size > 0)
+                        if not any(kind == "pause" for kind, _ in _parse_line_segments(hypno_line.text))
+                        else all(p.exists() and p.stat().st_size > 0 for p in temp_paths)
+                    )
+                    for hypno_line, segments, temp_paths in combine_jobs
                 ):
-                    logger.debug("Waiting for audio files to be fully written...")
+                    logger.debug("Waiting for all speech segment audio files to be fully written...")
                     time.sleep(FILE_WRITE_WAIT)
+
+                # Combine jobs (assemble pauses + speech)
+                for hypno_line, segments, temp_paths in combine_jobs:
+                    has_pause = any(kind == "pause" for kind, _ in segments)
+                    if not has_pause:
+                        # No combination needed
+                        continue
+
+                    # Build final audio
+                    combined = AudioSegment.silent(duration=0)
+                    temp_index = 0
+                    for kind, value in segments:
+                        if kind == "speech":
+                            try:
+                                seg_audio = AudioSegment.from_file(temp_paths[temp_index])
+                            except Exception as exc:  # noqa: BLE001
+                                logger.error(f"Failed loading speech segment for line '{hypno_line.text}': {exc}")
+                                seg_audio = AudioSegment.silent(duration=0)
+                            combined += seg_audio
+                            temp_index += 1
+                        else:  # pause
+                            try:
+                                seconds = float(value)
+                            except ValueError:
+                                logger.warning(f"Invalid pause duration '{value}' in line '{hypno_line.text}', skipping pause.")
+                                continue
+                            combined += AudioSegment.silent(duration=int(seconds * 1000))
+
+                    # Export combined to final filepath
+                    try:
+                        combined.export(hypno_line.filepath, format="wav")
+                    except Exception as exc:  # noqa: BLE001
+                        logger.error(f"Failed exporting combined line '{hypno_line.text}': {exc}")
+                    finally:
+                        # Clean up temp segment files
+                        for p in temp_paths:
+                            try:
+                                p.unlink(missing_ok=True)
+                            except Exception:  # noqa: BLE001
+                                pass
+
             else:
                 logger.debug("No new audio files to save.")
 
             # Getting all duration values for the lines
             for hypno_line in new_exported_files.values():
-                if not hypno_line.duration:
-                    hypno_line.set_duration()
+                if not hypno_line.duration and hypno_line.filepath.exists():
+                    try:
+                        hypno_line.set_duration()
+                    except FileNotFoundError:
+                        logger.error(f"Expected audio file missing for line: {hypno_line.text}")
 
             logger.debug("All audio files are now saved and non-empty.")
 
@@ -113,3 +219,101 @@ def generate_audio(
         else:
             logger.debug("No changes detected, waiting before checking again.")
             time.sleep(SLEEP_PERIOD)
+
+
+# Public helper for one-off batch generation (used by --render-mix path)
+# Generates audio for provided text lines if missing, respecting pause directives.
+# Returns a mapping of line text -> HypnoLine objects (with durations set).
+
+def generate_lines_once(text_lines: list[str], output_audio_dir: Path) -> dict[str, HypnoLine]:
+    engine = get_engine()
+    new_exported_files: dict[str, HypnoLine] = {}
+    combine_jobs: list[tuple[HypnoLine, list[tuple[str, str]], list[Path]]] = []
+    queued = 0
+
+    for line in text_lines:
+        if not line:
+            continue
+        hypno_line = HypnoLine.from_text(line, output_audio_dir)
+        segments = _parse_line_segments(line)
+        has_pause = any(kind == "pause" for kind, _ in segments)
+
+        if not hypno_line.filepath.exists():
+            if has_pause:
+                temp_paths: list[Path] = []
+                for idx, (kind, value) in enumerate(segments):
+                    if kind == "speech":
+                        temp_path = hypno_line.filepath.parent / f"{hypno_line.filepath.stem}_seg{idx}.tmp.wav"
+                        engine.save_to_file(value, str(temp_path))
+                        temp_paths.append(temp_path)
+                if temp_paths:
+                    queued += 1
+                combine_jobs.append((hypno_line, segments, temp_paths))
+            else:
+                if segments and segments[0][0] == "speech":
+                    engine.save_to_file(segments[0][1], str(hypno_line.filepath))
+                    queued += 1
+                else:
+                    logger.debug(f"Skipping empty or pause-only line during batch generation: {line}")
+
+        new_exported_files[line] = hypno_line
+
+    if queued:
+        logger.debug(f"Batch generating {queued} line audio files for mix render.")
+        engine.runAndWait()
+
+        # Wait for all speech segment files to exist (for paused lines) before combining
+        wait_attempts = 0
+        while not all(
+            (
+                (hypno_line.filepath.exists() and hypno_line.filepath.stat().st_size > 0)
+                if not any(kind == "pause" for kind, _ in _parse_line_segments(hypno_line.text))
+                else all(p.exists() and p.stat().st_size > 0 for p in temp_paths)
+            )
+            for hypno_line, segments, temp_paths in combine_jobs
+        ) and wait_attempts < 30:
+            time.sleep(FILE_WRITE_WAIT)
+            wait_attempts += 1
+
+        # Combine paused lines
+        for hypno_line, segments, temp_paths in combine_jobs:
+            if not any(kind == "pause" for kind, _ in segments):
+                continue
+            combined = AudioSegment.silent(duration=0)
+            temp_index = 0
+            for kind, value in segments:
+                if kind == "speech":
+                    try:
+                        seg_audio = AudioSegment.from_file(temp_paths[temp_index])
+                    except Exception as exc:  # noqa: BLE001
+                        logger.error(f"Failed loading batch speech segment for line '{hypno_line.text}': {exc}")
+                        seg_audio = AudioSegment.silent(duration=0)
+                    combined += seg_audio
+                    temp_index += 1
+                else:
+                    try:
+                        seconds = float(value)
+                    except ValueError:
+                        logger.warning(f"Invalid pause duration '{value}' in line '{hypno_line.text}' during batch gen.")
+                        continue
+                    combined += AudioSegment.silent(duration=int(seconds * 1000))
+            try:
+                combined.export(hypno_line.filepath, format="wav")
+            except Exception as exc:  # noqa: BLE001
+                logger.error(f"Failed exporting combined batch line '{hypno_line.text}': {exc}")
+            finally:
+                for p in temp_paths:
+                    try:
+                        p.unlink(missing_ok=True)
+                    except Exception:  # noqa: BLE001
+                        pass
+
+    # Set durations
+    for hypno_line in new_exported_files.values():
+        if hypno_line.filepath.exists():
+            try:
+                hypno_line.set_duration()
+            except FileNotFoundError:
+                logger.error(f"Missing expected generated file for line: {hypno_line.text}")
+
+    return new_exported_files


### PR DESCRIPTION
Added args 

- `--render-mix`: Render all lines, tone, and mantra into a single audio file (no playback). The mantra will begin at the configured `mantra_start_delay` (from your config). If that delay is longer than the total length of the rendered line audio, the mantra is skipped. Any missing hypnosis line audio is automatically generated first (including handling inline pause directives) before the mix is assembled.
- `--mix-output <filename>`: Specify the output file name for the rendered mix (default: `full_mix.wav`).

Updated documentation to mirror these changes
Updated Requirements
Added Inline Pause Directives ( [pause X seconds] in lines.txt gives pause to TTS)
